### PR TITLE
Add brew formula

### DIFF
--- a/Casks/refined-github-safari.rb
+++ b/Casks/refined-github-safari.rb
@@ -1,0 +1,18 @@
+cask 'refined-github-safari' do
+  version '2.0.15'
+  sha256 '3f224d6ef2553d0435217012284055d19192583e40a7875a381290d9cce0562e'
+
+  url "https://github.com/lautis/refined-github-safari/releases/download/v#{version}/Refined-GitHub-for-Safari.zip"
+  appcast 'https://github.com/lautis/refined-github-safari/releases.atom'
+  name 'refined-github-safari'
+  homepage 'https://github.com/lautis/refined-github-safari'
+
+  app 'Refined GitHub for Safari.app'
+
+  zap delete: [
+    '~/Library/Application Scripts/fi.lautanala.refined-github',
+    '~/Library/Application Scripts/fi.lautanala.refined-github-extension',
+    '~/Library/Containers/fi.lautanala.refined-github',
+    '~/Library/Containers/fi.lautanala.refined-github-extenstion'
+  ]
+end


### PR DESCRIPTION
Hi!

Thanks for building and maintaining this extension.

I found it tedious to update by hand, so decided to create a `homebrew` cask distribution for it.

It'll let you install this extension by:


```sh
brew tap lautis/refined-github-safari
brew cask install refined-github-safari
```

and update:

```sh
brew update
brew cask upgrade
```

Problems at hand:
- `homebrew` requires the repo name to begin with `homebrew-` so you'll have to either:
	- rename this repo to `homebrew-refined-github-safari` and merge this request.
	- Create a metarepo and move `Casks/refined-github-safari.rb` there

- I am not 100% sure if we'll need to update the cask spec with each release. (There is the appcast)

```rb
  version '2.0.15'
  sha256 '3f224d6ef2553d0435217012284055d19192583e40a7875a381290d9cce0562e'
```


To test this out with my fork you can:
```sh
brew tap epk/refined-github-safari
brew cask install refined-github-safari
```