### PR TITLE
Update README to point homebrew's formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ This is a Safari version of [Refined GitHub](https://github.com/sindresorhus/ref
 Or using homebrew:
 
 ```sh
-brew tap lautis/refined-github-safari
 brew cask install refined-github-safari
 ```
 


### PR DESCRIPTION
This PR updates the installation instructions to point to [homebrew's official formula](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/refined-github-safari.rb), as it was [accepted to homebrew-cask](https://github.com/Homebrew/homebrew-cask/pull/78233).